### PR TITLE
Correction de "troubleshoting" et de "faq"

### DIFF
--- a/doc/fr_FR/faq.asciidoc
+++ b/doc/fr_FR/faq.asciidoc
@@ -5,5 +5,5 @@ Non, mais pour une utilisation plus économique, le plugin a besoin de votre gé
 --
 .Comment gérer l'état de présence/absence autrement qu'avec la géolocalisation ?
 --
-Il est possible d'utiliser le plugin agenda qui permettra de définir des plages de présence et d'absence qui vont piloter les états des thermostats.
+Il est possible d'utiliser le plugin agenda qui permettra de définir des plages de présence et d'absence, les actions de l'agenda piloteront les états des thermostats.
 --

--- a/doc/fr_FR/faq.asciidoc
+++ b/doc/fr_FR/faq.asciidoc
@@ -1,5 +1,9 @@
 [panel,primary]
-.Le plugin nécessite t il des prérequis ?
+.Le plugin nécessite-t-il des prérequis ?
 --
 Non, mais pour une utilisation plus économique, le plugin a besoin de votre géolocalisation (ou a minima de connaitre l'état de présence/absence).
+--
+.Comment gérer l'état de présence/absence autrement qu'avec la géolocalisation ?
+--
+Il est possible d'utiliser le plugin agenda qui permettra de définir des plages de présence et d'absence qui vont piloter les états des thermostats.
 --

--- a/doc/fr_FR/troubleshoting.asciidoc
+++ b/doc/fr_FR/troubleshoting.asciidoc
@@ -3,8 +3,12 @@
 --
 J'ai rencontré des problèmes avec l'utilisation de min et max. Dans les valeurs à tester par min/max, il ne faut pas que deux parenthèses soient l'une derrière l'autre, donc "((" par exemple est à proscrire.
 J'ai rencontré le même genre de problème avec round.
+
 Exemple non valide :
+
 round (12+(3*2),1)
+
 Exemple valide :
+
 round (12+min(3*2,85496),1)
 --

--- a/doc/fr_FR/troubleshoting.asciidoc
+++ b/doc/fr_FR/troubleshoting.asciidoc
@@ -1,8 +1,7 @@
 [panel,danger]
 .Le calcul du pourcentage d'ajustement ne fonctionne pas
 --
-J'ai rencontré des problème avec l'utilisation de min et max. Dans les valeurs a tester par min/max,
-il ne faut pas que deux parenthèses soient l'une derrière l'autre, donc "((" par exemple est a proscrire.
+J'ai rencontré des problèmes avec l'utilisation de min et max. Dans les valeurs à tester par min/max, il ne faut pas que deux parenthèses soient l'une derrière l'autre, donc "((" par exemple est à proscrire.
 J'ai rencontré le même genre de problème avec round.
 Exemple non valide :
 round (12+(3*2),1)

--- a/doc/fr_FR/troubleshoting.asciidoc
+++ b/doc/fr_FR/troubleshoting.asciidoc
@@ -4,8 +4,7 @@
 J'ai rencontré des problèmes avec l'utilisation de min et max. Dans les valeurs à tester par min/max, il ne faut pas que deux parenthèses soient l'une derrière l'autre, donc "((" par exemple est à proscrire.
 J'ai rencontré le même genre de problème avec round.
 
-Exemple non valide :
-
+Exemple non valide : \br
 round (12+(3*2),1)
 
 Exemple valide :

--- a/doc/fr_FR/troubleshoting.asciidoc
+++ b/doc/fr_FR/troubleshoting.asciidoc
@@ -4,7 +4,8 @@
 J'ai rencontré des problèmes avec l'utilisation de min et max. Dans les valeurs à tester par min/max, il ne faut pas que deux parenthèses soient l'une derrière l'autre, donc "((" par exemple est à proscrire.
 J'ai rencontré le même genre de problème avec round.
 
-Exemple non valide : \br
+Exemple non valide :
+
 round (12+(3*2),1)
 
 Exemple valide :


### PR DESCRIPTION
Correction grammaticale des pages "troubleshoting" et "Faq".
Ajout d'une question/réponse dans la FAQ.

Question : Troubleshoting ne devrait-il pas être nommé "Troubleshooting" ? Cf. https://en.wikipedia.org/wiki/Troubleshooting
Je n'ai pas corrigé car je ne sais pas trop quelles sont les interactions entre les différents asciidoc.