### PR TITLE
Correction d'un accent sur événements

### DIFF
--- a/desktop/php/boilerThermostat.php
+++ b/desktop/php/boilerThermostat.php
@@ -186,7 +186,7 @@ $eqLogicsManager = eqLogic::byTypeAndSearhConfiguration('boilerThermostat','Mana
           <fieldset>
             <legend>{{Modes}} <a class="btn btn-success btn-xs pull-right" id="bt_addMode" style="margin-top: 5px;"><i class="fa fa-plus-circle"></i> {{Ajouter mode}}</a></legend>
             <div id="div_modes"></div>
-            <legend>{{Actionneurs (Propagation des évènements On/Off et changement de consigne)}} <a class="btn btn-success btn-xs pull-right" id="bt_addActuator" style="margin-top: 5px;"><i class="fa fa-plus-circle"></i> {{Ajouter actionneur}}</a></legend>
+            <legend>{{Actionneurs (Propagation des événements On/Off et changement de consigne)}} <a class="btn btn-success btn-xs pull-right" id="bt_addActuator" style="margin-top: 5px;"><i class="fa fa-plus-circle"></i> {{Ajouter actionneur}}</a></legend>
             <div id="div_actuators"></div>
           </fieldset>
         </form>


### PR DESCRIPTION
Juste un accent inversé sur le moment "événements".